### PR TITLE
fix: Fix expection when using the backspace feature

### DIFF
--- a/packages/terminui/lib/src/controller.dart
+++ b/packages/terminui/lib/src/controller.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:terminui/terminui.dart';
@@ -160,7 +162,10 @@ class TerminuiController<S> {
       });
     } else if (event.logicalKey == LogicalKeyboardKey.backspace) {
       state.value = state.value.copyWith(
-        cmd: state.value.cmd.substring(0, state.value.cmd.length - 1),
+        cmd: state.value.cmd.substring(
+          0,
+          max(state.value.cmd.length - 1, 0),
+        ),
       );
     } else if (char != null) {
       state.value = state.value.copyWith(


### PR DESCRIPTION
There is currently an exception when trying to use the backspace key when there are no characters in the buffer:
![image](https://github.com/user-attachments/assets/0c12a881-4d7f-4eca-a8bd-82a3744286d4)
This adds a simple bound check.